### PR TITLE
feat: add support for components specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can run the above examples and open the OpenAPI document in your browser:
 from dataclasses import dataclass
 from typing import List
 
-from defspec import OpenAPI
+from defspec import OpenAPI, OpenAPIComponent
 
 
 @dataclass
@@ -49,7 +49,17 @@ class User:
     age: int
 
 
-openapi = OpenAPI()
+openapi = OpenAPI(
+    components=OpenAPIComponent(
+        security_schemes={
+            "apiKey": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            }
+        }
+    )
+)
 openapi.register_route("/", method="get", summary="Hello World")
 openapi.register_route(
     "/users", method="post", summary="Get all the user info", response_type=List[User]

--- a/defspec/__init__.py
+++ b/defspec/__init__.py
@@ -1,4 +1,4 @@
-from defspec.spec import OpenAPI, OpenAPIInfo
+from defspec.spec import OpenAPI, OpenAPIComponent, OpenAPIInfo
 from defspec.template import RenderTemplate
 
-__all__ = ["OpenAPI", "OpenAPIInfo", "RenderTemplate"]
+__all__ = ["OpenAPI", "OpenAPIComponent", "OpenAPIInfo", "RenderTemplate"]


### PR DESCRIPTION
This pull request introduces support for OpenAPI components, specifically security schemes, across the codebase. The changes allow users to define and register security schemes (such as API keys or JWT bearer tokens) in their OpenAPI specifications, and ensure these are correctly represented in the generated spec and tested for accuracy.

**OpenAPI components and security schemes support:**

* Added the `OpenAPIComponent` class and integrated it into the `OpenAPI` specification, enabling users to define `security_schemes` and other components. [[1]](diffhunk://#diff-3ce1dcf6e884a619f1dc63de8b744ebc856e53cd78a8cbde5d40785e413dc5f3L77-R77) [[2]](diffhunk://#diff-3ce1dcf6e884a619f1dc63de8b744ebc856e53cd78a8cbde5d40785e413dc5f3R128)
* Updated usage examples and documentation in `README.md` to show how to initialize `OpenAPI` with security schemes, including JWT and API key examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R43) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R62) [[3]](diffhunk://#diff-3ce1dcf6e884a619f1dc63de8b744ebc856e53cd78a8cbde5d40785e413dc5f3L106-R119)
